### PR TITLE
chore: disable npm publish in release config

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,7 +4,7 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/npm", {
-      "npmPublish": true
+      "npmPublish": false
     }],
     ["@semantic-release/git", {
       "assets": ["package.json", "dist"],


### PR DESCRIPTION
## Summary
- disable npm publish in semantic-release config to avoid missing token error

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c1a6860988332b253094360c4fe78